### PR TITLE
Fix path resolution for vite server

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,10 +1,13 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
+import { fileURLToPath } from "url";
 import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
 import viteConfig from "../vite.config";
 import { nanoid } from "nanoid";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const viteLogger = createLogger();
 
@@ -46,7 +49,7 @@ export async function setupVite(app: Express, server: Server) {
 
     try {
       const clientTemplate = path.resolve(
-        import.meta.dirname,
+        __dirname,
         "..",
         "client",
         "index.html",
@@ -68,7 +71,7 @@ export async function setupVite(app: Express, server: Server) {
 }
 
 export function serveStatic(app: Express) {
-  const distPath = path.resolve(import.meta.dirname, "public");
+  const distPath = path.resolve(__dirname, "public");
 
   if (!fs.existsSync(distPath)) {
     throw new Error(


### PR DESCRIPTION
## Summary
- fix use of `import.meta.dirname`

## Testing
- `pnpm install` *(fails: 403 Forbidden)*
- `pnpm dev` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873c7a2a0308321a324cc7894ed0b44