### PR TITLE
Fix error handling type

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,12 @@ import session from "express-session";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 
+// Custom error shape used in the error handling middleware
+interface HttpError extends Error {
+  status?: number;
+  statusCode?: number;
+}
+
 const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
@@ -50,11 +56,12 @@ app.use((req, res, next) => {
   next();
 });
 
+
 (async () => {
   const server = await registerRoutes(app);
 
-  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
-    const status = err.status || err.statusCode || 500;
+  app.use((err: HttpError, _req: Request, res: Response, _next: NextFunction) => {
+    const status = err.status ?? err.statusCode ?? 500;
     const message = err.message || "Internal Server Error";
 
     res.status(status).json({ message });


### PR DESCRIPTION
## Summary
- add `HttpError` interface in the server
- use the new type in the express error handler

## Testing
- `pnpm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6873ccbae66083218354c8fff912847f